### PR TITLE
投稿新規作成機能追加

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -2,4 +2,8 @@ class PostsController < ApplicationController
   def index
     @posts = Post.includes(:user)
   end
+
+  def new
+    @post = Post.new
+  end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -6,4 +6,20 @@ class PostsController < ApplicationController
   def new
     @post = Post.new
   end
+
+  def create
+    @post = current_user.posts.build(post_params)
+    if @post.save
+      redirect_to posts_path, success: t('defaults.flash_message.created', item: Post.model_name.human)
+    else
+      flash.now[:danger] = t('defaults.flash_message.not_created', item: Post.model_name.human)
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def post_params
+    params.require(:post).permit(:title, :body)
+  end
 end

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,0 +1,22 @@
+<div class="max-w-md mx-auto bg-white rounded-lg shadow-md p-6 mt-24">
+  <%= form_with(model: @post) do |form| %>
+    <div class="mb-4">
+      <label class="block text-gray-700 text-sm font-bold mb-2">
+        タイトル
+      </label>
+      <%= form.text_field :title, class: "w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+    </div>
+
+    <div class="mb-4">
+      <label class="block text-gray-700 text-sm font-bold mb-2">
+        本文
+      </label>
+      <%= form.text_area :body, class: "w-full px-32 py-24 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none" %>
+    </div>
+ 
+  <div class="mb-4">
+    <%= form.submit "投稿する", class: "inline-flex items-center justify-center px-6 py-3 font-medium text-white bg-gradient-to-r from-orange-500 to-orange-600 rounded-full hover:from-orange-600 hover:to-orange-700 shadow-sm hover:shadow-md lg:px-4 lg:py-2 lg:w-auto transition-all duration-200" %>
+  </div>
+  <% end %>
+</div>
+

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -41,7 +41,7 @@
         trigger_id: 'board',
       menu_items: [
         { text: '掲示板一覧', path: posts_path },
-        { text: '掲示板作成', path: '#' }
+        { text: '掲示板作成', path: new_post_path }
       ] %>
 
       <%= link_to "Myマルシェ", "#", data: { "turbo-method": :delete }, class: "text-gray-600 hover:text-gray-800 px-4 py-2"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
     delete "logout", to: "users/sessions#destroy", as: :logout
   end
 
-  resources :posts, only: %i[index]
+  resources :posts, only: %i[index new]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
     delete "logout", to: "users/sessions#destroy", as: :logout
   end
 
-  resources :posts, only: %i[index new]
+  resources :posts, only: %i[index new create]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.


### PR DESCRIPTION
## 概要
投稿機能の新規作成フォームを実装しました。
ユーザーがタイトルと本文を入力して投稿できるようになります。

## 変更内容
### 追加したファイル
- `app/views/posts/new.html.erb` - 投稿作成フォーム
- `app/controllers/posts_controller.rb` - new, createアクション

### 変更したファイル  
- `config/routes.rb` - 投稿関連のルーティング追加

## 実装した機能
- [ ] 投稿作成フォーム（タイトル・本文入力）
- [ ] フォーム送信機能
- [ ] 投稿後の一覧表示
- [ ] レスポンシブデザイン対応

## 動作確認方法
1. `/posts/new` にアクセス
2. タイトルと本文を入力
3. 「投稿する」ボタンをクリック
4. 投稿一覧ページで新しい投稿が表示されることを確認

## スクリーンショット
フォーム画面
[![Image from Gyazo](https://i.gyazo.com/a71da9170f5b5fe0931ddb141c43c682.png)](https://gyazo.com/a71da9170f5b5fe0931ddb141c43c682)

投稿後の一覧画面
[![Image from Gyazo](https://i.gyazo.com/254adfd41d065a0333f6897d6308cb49.png)](https://gyazo.com/254adfd41d065a0333f6897d6308cb49)

## 注意点・今後の課題
- バリデーションは次のPRで実装予定
