### PR TITLE
add：カテゴリー追加

### DIFF
--- a/app/controllers/marches_controller.rb
+++ b/app/controllers/marches_controller.rb
@@ -9,32 +9,29 @@ class MarchesController < ApplicationController
   def new
     @marche = Marche.new
     @atmospheres = Atmosphere.all
+    @targets = Target.all
+    @prices = Price.all
   end
 
-   def create
+  def create
     @marche = current_user.marches.build(marche_params)
-
-    logger.debug("受信したparams: #{params}")
-    logger.debug("marche_params: #{marche_params}")
-    logger.debug("atmosphere_ids: #{marche_params[:atmosphere_ids]}")
-  
-  # デバッグ用：paramsの中身を確認
-    logger.debug("params: #{params}")
   
     if @marche.save
       redirect_to marches_path
     else
       @atmospheres = Atmosphere.all
+      @targets = Target.all
+      @prices = Price.all
       render :new, status: :unprocessable_entity
     end
   end
 
-  def show
-    logger.debug("marche atmospheres: #{@marche.atmospheres.pluck(:name)}")
-  end
+  def show; end
 
   def edit
     @atmospheres = Atmosphere.all 
+    @targets = Target.all
+    @prices = Price.all
   end
 
   def update
@@ -55,10 +52,9 @@ class MarchesController < ApplicationController
 
   def set_marche
     @marche = current_user.marches.find(params[:id])
-
   end
 
   def marche_params
-    params.require(:marche).permit(:title, :body, :location,{ images: []}, :start_at, :end_at, atmosphere_ids: [] )
+    params.require(:marche).permit(:title, :body, :location,{ images: []}, :start_at, :end_at, atmosphere_ids: [], target_ids: [], price_ids: [] )
   end
 end

--- a/app/models/marche.rb
+++ b/app/models/marche.rb
@@ -7,4 +7,8 @@ class Marche < ApplicationRecord
   mount_uploaders :images, ImageUploader  
   has_many :marche_atmospheres, dependent: :destroy 
   has_many :atmospheres, through: :marche_atmospheres, source: :atmosphere
+  has_many :marche_targets, dependent: :destroy 
+  has_many :targets, through: :marche_targets, source: :target
+  has_many :marche_prices, dependent: :destroy 
+  has_many :prices, through: :marche_prices, source: :price
 end

--- a/app/models/marche_price.rb
+++ b/app/models/marche_price.rb
@@ -1,0 +1,6 @@
+class MarchePrice < ApplicationRecord
+  belongs_to :marche
+  belongs_to :price
+
+  validates :marche_id, uniqueness: { scope: :price_id }
+end

--- a/app/models/marche_target.rb
+++ b/app/models/marche_target.rb
@@ -1,0 +1,6 @@
+class MarcheTarget < ApplicationRecord
+  belongs_to :marche
+  belongs_to :target
+
+  validates :marche_id, uniqueness: { scope: :target_id }
+end

--- a/app/models/price.rb
+++ b/app/models/price.rb
@@ -1,0 +1,3 @@
+class Price < ApplicationRecord
+  has_many :marche_prices, dependent: :destroy
+end

--- a/app/models/target.rb
+++ b/app/models/target.rb
@@ -1,0 +1,3 @@
+class Target < ApplicationRecord
+  has_many :marche_targets, dependent: :destroy
+end

--- a/app/views/marches/edit.html.erb
+++ b/app/views/marches/edit.html.erb
@@ -45,7 +45,7 @@
     </div>
 
     <div class="field mb-4">
-      <%= form.label :atmosphere_ids, "雰囲気を選択", class: "block text-sm font-medium text-gray-700 mb-2" %>
+      <%= form.label :atmosphere_ids, "キーワードを選択", class: "block text-sm font-medium text-gray-700 mb-2" %>
     
       <div class="atmosphere-checkboxes space-y-2">
         <% @atmospheres.each do |atmosphere| %>
@@ -58,6 +58,46 @@
               }, 
               atmosphere.id, "" %>
             <%= form.label "atmosphere_ids_#{atmosphere.id}", atmosphere.name, 
+              class: "text-sm text-gray-700" %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+
+    <div class="field mb-4">
+      <%= form.label :target_ids, "ターゲットを選択", class: "block text-sm font-medium text-gray-700 mb-2" %>
+    
+      <div class="target-checkboxes space-y-2">
+        <% @targets.each do |target| %>
+          <div class="flex items-center">
+            <%= form.check_box :target_ids, 
+              { 
+                multiple: true, 
+                checked: @marche.target_ids.include?(target.id),
+                class: "mr-2"
+              }, 
+              target.id, "" %>
+            <%= form.label "target_ids_#{target.id}", target.name, 
+              class: "text-sm text-gray-700" %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+
+    <div class="field mb-4">
+      <%= form.label :target_ids, "価格帯を選択", class: "block text-sm font-medium text-gray-700 mb-2" %>
+    
+      <div class="target-checkboxes space-y-2">
+        <% @prices.each do |price| %>
+          <div class="flex items-center">
+            <%= form.check_box :price_ids, 
+              { 
+                multiple: true, 
+                checked: @marche.price_ids.include?(price.id),
+                class: "mr-2"
+              }, 
+              price.id, "" %>
+            <%= form.label "price_ids_#{price.id}", price.name, 
               class: "text-sm text-gray-700" %>
           </div>
         <% end %>

--- a/app/views/marches/index.html.erb
+++ b/app/views/marches/index.html.erb
@@ -1,4 +1,4 @@
-div class="container mx-auto px-4 py-6">
+<div class="container mx-auto px-4 py-20">
   <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
     <% @marches.each do |marche| %>
       <!-- ここを修正！ -->
@@ -66,6 +66,35 @@ div class="container mx-auto px-4 py-6">
         <div class="p-4">
           <h3 class="text-lg font-semibold mb-2"><%= marche.title %></h3>
           <p class="text-gray-600 text-sm"><%= truncate(marche.body, length: 100) %></p>
+          <% if marche.atmospheres.any? %>
+           <div class="mt-2">
+             <% marche.atmospheres.each do |atmosphere| %>
+               <span class="inline-block bg-orange-300 text-gray-600 text-xs px-2 py-1 rounded mr-1">
+               <%= atmosphere.name %>
+               </span>
+              <% end %>
+           </div>
+          <% end %>
+          <% if marche.targets.any? %>
+           <div class="mt-2">
+             <% marche.targets.each do |target| %>
+               <span class="inline-block bg-green-300 text-green-600 text-xs px-2 py-1 rounded mr-1">
+               <%= target.name %>
+               </span>
+              <% end %>
+           </div>
+          <% end %>
+
+          <% if marche.prices.any? %>
+           <div class="mt-2">
+             <% marche.prices.each do |price| %>
+               <span class="inline-block bg-blue-300 text-gray-600 text-xs px-2 py-1 rounded mr-1">
+               <%= price.name %>
+               </span>
+              <% end %>
+           </div>
+          <% end %>
+
           <%= link_to "詳細を見る", marche_path(marche), 
                 class: "text-blue-500 hover:text-blue-700 text-sm font-medium" %>
         </div>

--- a/app/views/marches/new.html.erb
+++ b/app/views/marches/new.html.erb
@@ -56,6 +56,32 @@
         </div>
       <% end %>
     </div>
+
+    <div class="flex flex-wrap ">
+      <label class="block text-gray-700 text-sm font-bold mb-2">
+      ターゲット（複数選択可能）
+      </label>
+  
+      <% @targets.each do |target| %>
+        <div class="flex items-center mb-2">
+          <%= form.check_box :target_ids, { multiple: true }, target.id, "" %>
+          <%= form.label :target_ids, target.name, value: target.id %>
+        </div>
+      <% end %>
+    </div>
+
+    <div class="flex flex-wrap ">
+      <label class="block text-gray-700 text-sm font-bold mb-2">
+      価格帯（複数選択可能）
+      </label>
+  
+      <% @prices.each do |price| %>
+        <div class="flex items-center mb-2">
+          <%= form.check_box :price_ids, { multiple: true }, price.id, "" %>
+          <%= form.label :price_ids, price.name, value: price.id %>
+        </div>
+      <% end %>
+    </div>
  
   <div class="mb-4">
     <%= form.submit "投稿する", class: "inline-flex items-center justify-center px-6 py-3 font-medium text-white bg-gradient-to-r from-orange-500 to-orange-600 rounded-full hover:from-orange-600 hover:to-orange-700 shadow-sm hover:shadow-md lg:px-4 lg:py-2 lg:w-auto transition-all duration-200" %>

--- a/app/views/marches/show.html.erb
+++ b/app/views/marches/show.html.erb
@@ -1,4 +1,4 @@
-<div class="container mx-auto pt-12">
+<div class="container mx-auto pt-20">
   <h1 class="text-2xl font-bold mb-6">マルシェ詳細</h1>
   <article class="bg-white rounded-lg shadow-md">
     <div class="p-6">
@@ -19,11 +19,27 @@
           <%= @marche.start_at.strftime("%Y年%m月%d日 %H:%M") %>
           <%= @marche.end_at.strftime("%Y年%m月%d日 %H:%M") %>
           <div class="atmospheres">
-            <h4>雰囲気</h4>
+            <h4>キーワード</h4>
             <% @marche.atmospheres.each do |atmosphere| %>
-              <span class="bg-blue-100 text-blue-800 px-3 py-1 rounded-full mr-2">
+              <span class="bg-orange-200 text-orange-600 px-3 py-1 rounded-full mr-2">
               <%= atmosphere.name %>
              </span>
+            <% end %>
+          </div>
+          <div class="targets">
+            <h4>ターゲット</h4>
+            <% @marche.targets.each do |target| %>
+              <span class="bg-green-100 text-green-800 px-3 py-1 rounded-full mr-2">
+              <%= target.name %>
+             </span>
+            <% end %>
+          </div>
+          <div class="prices">
+            <h4>価格帯</h4>
+            <% @marche.prices.each do |price| %>
+              <span class="bg-blue-100 text-blue-800 px-3 py-1 rounded-full mr-2">
+              <%= price.name %>
+              </span>
             <% end %>
           </div>
         </div>

--- a/db/migrate/20250731062713_create_marche_atmospheres.rb
+++ b/db/migrate/20250731062713_create_marche_atmospheres.rb
@@ -8,3 +8,5 @@ class CreateMarcheAtmospheres < ActiveRecord::Migration[7.2]
     add_index :marche_atmospheres, [:marche_id, :atmosphere_id], unique: true
   end
 end
+
+

--- a/db/migrate/20250801031807_create_targets.rb
+++ b/db/migrate/20250801031807_create_targets.rb
@@ -1,0 +1,8 @@
+class CreateTargets < ActiveRecord::Migration[7.2]
+  def change
+    create_table :targets do |t|
+      t.string :name
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250801032753_create_marche_targets.rb
+++ b/db/migrate/20250801032753_create_marche_targets.rb
@@ -1,0 +1,10 @@
+class CreateMarcheTargets < ActiveRecord::Migration[7.2]
+  def change
+    create_table :marche_targets do |t|
+      t.references :marche, foreign_key: true
+      t.references :target, foreign_key: true
+      t.timestamps
+    end
+    add_index :marche_targets, [:marche_id, :target_id], unique: true
+  end
+end

--- a/db/migrate/20250801085434_create_prices.rb
+++ b/db/migrate/20250801085434_create_prices.rb
@@ -1,0 +1,8 @@
+class CreatePrices < ActiveRecord::Migration[7.2]
+  def change
+    create_table :prices do |t|
+      t.string :name
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250801085537_create_marche_prices.rb
+++ b/db/migrate/20250801085537_create_marche_prices.rb
@@ -1,0 +1,10 @@
+class CreateMarchePrices < ActiveRecord::Migration[7.2]
+  def change
+    create_table :marche_prices do |t|
+      t.references :marche, foreign_key: true
+      t.references :price, foreign_key: true
+      t.timestamps
+    end
+    add_index :marche_prices, [:marche_id, :price_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_31_063441) do
+ActiveRecord::Schema[7.2].define(version: 2025_08_01_085537) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -27,6 +27,26 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_31_063441) do
     t.datetime "updated_at", null: false
     t.index ["atmosphere_id"], name: "index_marche_atmospheres_on_atmosphere_id"
     t.index ["marche_id"], name: "index_marche_atmospheres_on_marche_id"
+  end
+
+  create_table "marche_prices", force: :cascade do |t|
+    t.bigint "marche_id"
+    t.bigint "price_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["marche_id", "price_id"], name: "index_marche_prices_on_marche_id_and_price_id", unique: true
+    t.index ["marche_id"], name: "index_marche_prices_on_marche_id"
+    t.index ["price_id"], name: "index_marche_prices_on_price_id"
+  end
+
+  create_table "marche_targets", force: :cascade do |t|
+    t.bigint "marche_id"
+    t.bigint "target_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["marche_id", "target_id"], name: "index_marche_targets_on_marche_id_and_target_id", unique: true
+    t.index ["marche_id"], name: "index_marche_targets_on_marche_id"
+    t.index ["target_id"], name: "index_marche_targets_on_target_id"
   end
 
   create_table "marches", force: :cascade do |t|
@@ -52,6 +72,18 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_31_063441) do
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 
+  create_table "prices", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "targets", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -66,6 +98,10 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_31_063441) do
 
   add_foreign_key "marche_atmospheres", "atmospheres"
   add_foreign_key "marche_atmospheres", "marches"
+  add_foreign_key "marche_prices", "marches"
+  add_foreign_key "marche_prices", "prices"
+  add_foreign_key "marche_targets", "marches"
+  add_foreign_key "marche_targets", "targets"
   add_foreign_key "marches", "users"
   add_foreign_key "posts", "users"
 end

--- a/test/fixtures/marche_prices.yml
+++ b/test/fixtures/marche_prices.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/marche_targets.yml
+++ b/test/fixtures/marche_targets.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/prices.yml
+++ b/test/fixtures/prices.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/targets.yml
+++ b/test/fixtures/targets.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/marche_price_test.rb
+++ b/test/models/marche_price_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class MarchePriceTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/marche_target_test.rb
+++ b/test/models/marche_target_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class MarcheTargetTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/price_test.rb
+++ b/test/models/price_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class PriceTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/target_test.rb
+++ b/test/models/target_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class TargetTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
##概要
マルシェ新規登録・編集時にターゲット、価格帯カテゴリーを選択できる機能を実装

##変更内容
マルシェとターゲット、価格帯の多対多関連を実装
新規登録・編集画面にチェックボックス形式のターゲット、価格帯選択を追加
詳細画面に選択されたターゲット、価格帯を表示
マルシェ削除時に関連するターゲット、価格帯も削除される設定

##実装した機能
 ターゲット、価格帯カテゴリーの新規登録時選択機能
 ターゲット、価格帯カテゴリーの編集機能（追加・削除・変更）
 詳細画面での ターゲット、価格帯表示機能
 マルシェ削除時の関連データ削除機能

##技術的な実装詳細
モデル設計
Target,Price モデルの作成
MarcheTarget 中間テーブルの作成
MarchePrice 中間テーブルの作成
has_many through による多対多関連の実装
画面実装
collection_check_boxes を使用したフォーム実装
編集時の選択状態保持機能
レスポンシブデザイン対応

##テスト確認項目
 新規登録時にターゲット、価格帯を選択できる
 編集時にターゲット、価格帯を追加・削除できる
 詳細画面で選択されたターゲット、価格帯が表示される
 マルシェ削除時に関連データも削除される
 バリデーションエラー時に選択状態が保持される