### PR TITLE
出展者情報をユーザー情報に追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,3 +61,4 @@ end
   gem "rails-i18n", "~> 7.0.0"
   gem "carrierwave", "2.2.2"
   gem 'ransack', '~> 4.0'
+  gem 'letter_opener_web', '2.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,8 @@ GEM
       marcel (~> 1.0.0)
       mini_mime (>= 0.1.3)
       ssrf_filter (~> 1.0)
+    childprocess (5.1.0)
+      logger (~> 1.5)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
     crass (1.0.6)
@@ -147,6 +149,17 @@ GEM
       railties (>= 6.0.0)
     json (2.13.0)
     language_server-protocol (3.17.0.5)
+    launchy (3.1.1)
+      addressable (~> 2.8)
+      childprocess (~> 5.0)
+      logger (~> 1.6)
+    letter_opener (1.10.0)
+      launchy (>= 2.2, < 4)
+    letter_opener_web (2.0.0)
+      actionmailer (>= 5.2)
+      letter_opener (~> 1.7)
+      railties (>= 5.2)
+      rexml
     lint_roller (1.1.0)
     logger (1.7.0)
     loofah (2.24.1)
@@ -363,6 +376,7 @@ DEPENDENCIES
   devise
   jbuilder
   jsbundling-rails
+  letter_opener_web (= 2.0.0)
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.2.2, >= 7.2.2.1)

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -22,6 +22,7 @@ class MypagesController < ApplicationController
   private
 
   def mypage_params
-    params.require(:user).permit(:username, :hometown, :gender, :age, :instagram, :image )
+    params.require(:user).permit(:username, :hometown, :gender, :age, :instagram, :image, :shop_name, :products, :experience,
+    :contact_info, :self_pr )
   end
 end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -2,33 +2,33 @@
 
 class Users::PasswordsController < Devise::PasswordsController
   # GET /resource/password/new
-  # def new
-  #   super
-  # end
+  def new
+    super
+  end
 
   # POST /resource/password
-  # def create
-  #   super
-  # end
+  def create
+    super
+  end
 
   # GET /resource/password/edit?reset_password_token=abcdef
-  # def edit
-  #   super
-  # end
+  def edit
+   super
+  end
 
   # PUT /resource/password
-  # def update
-  #   super
-  # end
+  def update
+    super
+  end
 
-  # protected
+ protected
 
-  # def after_resetting_password_path_for(resource)
-  #   super(resource)
-  # end
+  def after_resetting_password_path_for(resource)
+    super(resource)
+  end
 
   # The path used after sending reset password instructions
-  # def after_sending_reset_password_instructions_path_for(resource_name)
-  #   super(resource_name)
-  # end
+  def after_sending_reset_password_instructions_path_for(resource_name)
+    super(resource_name)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,4 +16,9 @@ class User < ApplicationRecord
   validates :gender, presence: true, inclusion: { in: ['男性', '女性', 'その他'] }, on: :registration
   validates :age, presence: true, numericality: { greater_than: 0, less_than: 150 },  on: :registration
   validates :instagram, format: { with: /\A@?[a-zA-Z0-9_.]+\z/ }, allow_blank: true,  on: :registration
+  validates :shop_name, presence: true, length: { maximum: 50 }, on: :registration
+  validates :products, presence: true, length: { maximum: 255 }, on: :registration
+  validates :experience, presence: true, inclusion: { in: ['初回', '2～5回', '6回以上'] }, on: :registration
+  validates :contact_info, presence: true, length: { maximum: 50 }, on: :registration
+  validates :self_pr, presence: true, length: { maximum: 255 }, on: :registration
 end

--- a/app/views/devise/mailer/password_change.html.erb
+++ b/app/views/devise/mailer/password_change.html.erb
@@ -1,3 +1,3 @@
-<p>Hello <%= @resource.email %>!</p>
+<p>こんにちは<%= @resource.email %>!</p>
 
-<p>We're contacting you to notify you that your password has been changed.</p>
+<p>パスワードが変更されたことをお知らせするためにご連絡しています。</p>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,10 @@
-<p>Hello <%= @resource.email %>!</p>
+<p>こんにちは <%= @resource.email %>!</p>
 
-<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+<p>パスワードをリセットするためのリンクをお送りします。</p>
+<p>以下をクリックして、新しいパスワードを設定してください。</p>
 
-<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+<p><%= link_to 'パスワード再設定', edit_password_url(@resource, reset_password_token: @token) %></p>
 
-<p>If you didn't request this, please ignore this email.</p>
-<p>Your password won't change until you access the link above and create a new one.</p>
+<p>
+もし、心当たりがない場合はこのメールを無視してください。</p>
+<p>パスワードは、上記のリンクにアクセスして新しいパスワードを作成するまで変更されません。</p>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,25 +1,36 @@
-<h2>Change your password</h2>
+<div class="min-h-screen flex items-center justify-center bg-[oklch(95.3%_0.051_180.801)] py-12 px-4 sm:px-6 lg:px-8">
+  <div class="max-w-md w-full space-y-8">
+    <div>
+      <h2 class=" text-center text-4xl text-gray-500">
+      パスワード再設定
+      </h2>
+    </div>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
-  <%= f.hidden_field :reset_password_token %>
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+      <%= render "devise/shared/error_messages", resource: resource %>
+      <%= f.hidden_field :reset_password_token %>
 
-  <div class="field">
-    <%= f.label :password, "New password" %><br />
-    <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
+      <div class="field">
+        <%= f.label :password, "新しいパスワード", class: "block text-base text-xl text-gray-500 " %><br />
+       <%= f.password_field :password, autofocus: true, autocomplete: "new-password", class: "border-4 border-orange-400/50 appearance-none rounded-md relative block w-full px-4 py-3 text-base" %>
+       <% if @minimum_password_length %>
+          <em>(<%= @minimum_password_length %> 文字以上)</em><br />
+        <% end %>
+      </div>
+
+      <div class="field">
+        <%= f.label :password_confirmation, "パスワード（確認用）", class: "block text-base text-xl text-gray-500 mt-6" %><br />
+        <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "border-4 border-orange-400/50 appearance-none rounded-md relative block w-full px-4 py-3 text-base" %>
+      </div>
+
+      <div class="actions flex justify-center">
+        <button class="inline-flex items-center justify-center px-6 py-3 font-medium text-white bg-gradient-to-r from-orange-500 to-orange-600 rounded-full hover:from-orange-600 hover:to-orange-700 shadow-sm hover:shadow-md lg:px-4 lg:py-3 lg:w-auto transition-all duration-200 mt-6"
+           style="...">
+        パスワード変更
+        </button>
+      </div>
     <% end %>
-    <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
-  </div>
 
-  <div class="field">
-    <%= f.label :password_confirmation, "Confirm new password" %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Change my password" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+    <%= render "devise/shared/links" %>
+</div>
+</div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,16 +1,28 @@
-<h2>Forgot your password?</h2>
+<div class="min-h-screen flex items-center justify-center bg-[oklch(95.3%_0.051_180.801)] py-12 px-4 sm:px-6 lg:px-8">
+  <div class="max-w-md w-full space-y-8">
+    <div>
+      <h2 class="mt-6 text-center text-4xl text-gray-500">
+      パスワードリセット
+      </h2>
+    </div>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+      <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+      <div class="field">
+        <%= f.label :email, class: "block text-base text-xl text-gray-500 mb-2" %><br />
+        <%= f.email_field :email, class: "border-4 border-orange-400/50 appearance-none rounded-md relative block w-full px-4 py-3 border border-gray-300 text-base", autofocus: true, autocomplete: "email" %>
+      </div>
+
+  
+      <div class="actions flex justify-center">
+        <button class="inline-flex items-center justify-center px-6 py-3 font-medium text-white bg-gradient-to-r from-orange-500 to-orange-600 rounded-full hover:from-orange-600 hover:to-orange-700 shadow-sm hover:shadow-md lg:px-6 lg:py-3 lg:w-auto transition-all duration-200 mt-6"
+            style="...">
+        送信
+        </button>
+      </div>
+    <% end %>
+
+    <%= render "devise/shared/links" %>
   </div>
-
-  <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/marches/join_marches/index.html.erb
+++ b/app/views/marches/join_marches/index.html.erb
@@ -1,13 +1,31 @@
 <h1 class="text-xl font-bold"><%= @marche.title %>の参加者管理</h1>
 <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-12">
   <% @join_marches.each do |join_marche| %>
-    <div class="bg-white rounded-lg shadow-md overflow-hidden hover:shadow-lg transition-shadow">
+    <div class="bg-white rounded-lg shadow-md overflow-hidden hover:shadow-lg transition-shadow w-120 h-150">
       <!-- 参加者情報 -->
       <div class="p-10">
-        <h3 class="text-xl font-bold"><%= join_marche.user.username %></h3>
-        <p class="text-xl text-gray-600">申請日: <%= join_marche.created_at.strftime("%Y/%m/%d") %></p>
+        <h3 class="text-xl font-bold mb-4">ショップ名：<%= join_marche.user.shop_name %></h3>
+        <p class="text-xl font-bold mb-4">商品：<%= join_marche.user.products %></p>
+        <p class="text-xl font-bold mb-4">出店回数：<%= join_marche.user.experience %></p>
+        <p class="text-xl font-bold mb-4">連絡先：<%= join_marche.user.contact_info %></p>
+        <p class="text-xl text-gray-600 mb-8">
+            Instagram: 
+              <% if join_marche.user.instagram.present? %>
+                <%= link_to "@#{join_marche.user.instagram}", 
+                 "https://instagram.com/#{join_marche.user.instagram}", 
+                  target: "_blank", 
+                  class: "text-pink-500 hover:underline" %>
+              <% else %>
+                未設定
+              <% end %>
+        </p>
+        自己PR：
+        <div class="border border-gray-500 p-4 rounded-md mb-4">
+        <p class="text-xl font-bold "><%= join_marche.user.self_pr %></p>
+        </div>
+        <p class="text-xl text-gray-600 mb-4">申請日: <%= join_marche.created_at.strftime("%Y/%m/%d") %></p>
         <p class="text-xl">現在のステータス: 
-          <span class="px-3 py-1 rounded bg-gray-100">
+          <span class="px-3 py-1 rounded bg-orange-100">
             <%= join_marche.approval_status_display %>
           </span>
         </p>
@@ -15,7 +33,7 @@
       
       <!-- 個別の更新フォーム -->
       <%= form_with model: [@marche, join_marche], method: :patch, class: "status-update-form" do |form| %>
-        <div class="flex items-center gap-3">
+        <div class="flex items-center justify-center gap-3">
           <%= form.select :approval_status, 
               options_for_select([
                 ['選定中', 'pending'],

--- a/app/views/mypage/edit.html.erb
+++ b/app/views/mypage/edit.html.erb
@@ -45,6 +45,42 @@
       <%= form.text_field :instagram, class: "w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500" %>
     </div>
 
+    <div class="mb-4">
+      <label class="block text-gray-700 text-sm font-bold mb-2">
+        ショップ名（出展者のみ）
+      </label>
+      <%= form.text_field :shop_name, class: "w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+    </div>
+
+    <div class="mb-4">
+      <label class="block text-gray-700 text-sm font-bold mb-2">
+        商品内容（出展者のみ）
+      </label>
+      <%= form.text_field :products, class: "w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+    </div>
+
+    <div class="mb-4">
+      <label class="block text-gray-700 text-sm font-bold mb-2">
+        出店回数（何回目）（出展者のみ）
+      </label>
+      <%= form.select :experience, ['初回', '2～5回', '6回以上'], {}, { class: "w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500" } %>
+    </div>
+
+    <div class="mb-4">
+      <label class="block text-gray-700 text-sm font-bold mb-2">
+        連絡先（出展者のみ）
+      </label>
+      <%= form.text_field :contact_info, class: "w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+    </div>
+
+    <div class="mb-4">
+      <label class="block text-gray-700 text-sm font-bold mb-2">
+        自己PR（出展者のみ）
+      </label>
+      <%= form.text_field :self_pr, class: "w-full px-14 py-8 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+    </div>
+
+
   <div class="mb-4">
     <%= form.submit "更新する", class: "inline-flex items-center justify-center px-6 py-3 font-medium text-white bg-gradient-to-r from-orange-500 to-orange-600 rounded-full hover:from-orange-600 hover:to-orange-700 shadow-sm hover:shadow-md lg:px-4 lg:py-2 lg:w-auto transition-all duration-200" %>
   </div>

--- a/app/views/mypage/show.html.erb
+++ b/app/views/mypage/show.html.erb
@@ -22,10 +22,10 @@
           </h4>
           
           <p class="text-xl text-gray-600 mb-8">
-            性別: <%= current_user.gender.present? ? current_user.gender : "未設定" %> <!-- ここを埋めてみてください -->
+            性別: <%= current_user.gender.present? ? current_user.gender : "未設定" %> 
           </p>
           <p class="text-xl text-gray-600 mb-8">
-            年齢: <%= current_user.age.present? ? current_user.age : "未設定" %> <!-- ここを埋めてみてください -->
+            年齢: <%= current_user.age.present? ? current_user.age : "未設定" %>
           </p>
 
           <p class="text-xl text-gray-600 mb-8">
@@ -39,6 +39,29 @@
                 未設定
               <% end %>
           </p>
+
+          <h5 class="text-xl font-bold text-gray-600 mb-8">出展者情報</h5>
+          <p class="text-xl text-gray-600 mb-8 mt-6">
+            ショップ名:<%= current_user.shop_name.present? ? current_user.shop_name : "未設定" %>
+          </p>
+
+          <p class="text-xl text-gray-600 mb-8">
+            商品:<%= current_user.products.present? ? current_user.products : "未設定" %>
+          </p>
+
+          <p class="text-xl text-gray-600 mb-8">
+            出店経験:<%= current_user.experience.present? ? current_user.experience : "未設定" %>
+          </p>
+
+          <p class="text-xl text-gray-600 mb-8">
+            連絡先:<%= current_user.contact_info.present? ? current_user.contact_info : "未設定" %>
+          </p>
+
+          <p class="text-xl text-gray-600 mb-8">
+            自己PR:<%= current_user.self_pr.present? ? current_user.self_pr : "未設定" %>
+          </p>
+
+
         </div>
       </div>      
       <!-- ボタン部分 -->

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -40,7 +40,8 @@ Rails.application.configure do
   # Disable caching for Action Mailer templates even if Action Controller
   # caching is enabled.
   config.action_mailer.perform_caching = false
-
+  
+  config.action_mailer.delivery_method = :letter_opener_web
   config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
 
   # Print deprecation notices to the Rails logger.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,10 @@
 Rails.application.routes.draw do
+  mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
 
   devise_for :users, controllers: {
    registrations: "users/registrations",
-   sessions:       "users/sessions"
+   sessions:       "users/sessions",
+   passwords: "users/passwords"
    }
   root "homes#index"
 

--- a/db/migrate/20250808022927_add_seller_info_to_users.rb
+++ b/db/migrate/20250808022927_add_seller_info_to_users.rb
@@ -1,0 +1,9 @@
+class AddSellerInfoToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :shop_name, :string
+    add_column :users, :products, :text
+    add_column :users, :experience, :string
+    add_column :users, :contact_info, :string
+    add_column :users, :self_pr, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_08_07_074057) do
+ActiveRecord::Schema[7.2].define(version: 2025_08_08_022927) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -111,6 +111,11 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_07_074057) do
     t.integer "age"
     t.string "instagram"
     t.string "image"
+    t.string "shop_name"
+    t.text "products"
+    t.string "experience"
+    t.string "contact_info"
+    t.text "self_pr"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
概要
ユーザー情報に出展者情報（ショップ名、商品内容、出店経験、連絡先、自己PR）を追加しました。

実装した機能
マルシェ開催者向け機能

自分が開催するマルシェへの参加申請者一覧表示に
ユーザー情報（ショップ名、商品内容、出店経験、連絡先、自己PR）が表示される

出展者側
マイページのユーザー情報から出店情報を登録できる
マルシェに出店するボタンを押すと自動的に情報が開催者に送信される

変更ファイル
app/views/mypage/show.html.erb - ユーザー情報詳細ページ
app/views/mypage/show.html.erb- ユーザー情報編集ページ
app/views/marches/join_marches/index.html.erb - 参加申請者一覧画面

修正
config/routes.rb - ルーティング追加
app/contlollers/mypage.contloller.rb - パラメーター追加

確認方法
マルシェ開催者として
マルシェを作成済みのユーザーでログイン
/marches/:id/join_marches にアクセス
参加申請者一覧が表示されることを確認
ユーザーの出店情報が表示されているか確認
